### PR TITLE
fix(upgrade): fixes downgrade issue for signal based inputs

### DIFF
--- a/packages/upgrade/src/common/src/downgrade_component_adapter.ts
+++ b/packages/upgrade/src/common/src/downgrade_component_adapter.ts
@@ -320,7 +320,7 @@ export class DowngradeComponentAdapter {
     }
 
     this.inputChangeCount++;
-    componentRef.instance[prop] = currValue;
+    componentRef.setInput(prop, currValue);
   }
 
   private groupProjectableNodes() {


### PR DESCRIPTION
Fix issue where setting inputs did not work if the component used signal based inputs resulting in errors.

Switching to `setInput` API will correctly set the inputs.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Signal based inputs get the raw value instead of the signal function causing `not a function` error.

Issue Number: N/A


## What is the new behavior?
Using `setInput` correctly sets the input on the component. If the input is signal based then it wraps the value in the signal prior to setting it in the component.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
